### PR TITLE
fix: fixed issue where user was prompted more than once per Tweet to add alt text

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -41,15 +41,14 @@ function a11yCheck(event) {
     return;
   }
 
+  askedOnce = true;
+
   const shouldAddDescriptions = confirm(ADD_DESCRIPTIONS_MESSAGE);
 
   if (shouldAddDescriptions) {
-    askedOnce = true;
     event.preventDefault();
     event.stopPropagation();
     missingAltTextLink.click();
-  } else {
-    askedOnce = false;
   }
 }
 


### PR DESCRIPTION
## Description

Now the user is only prompted once per Tweet to add alt text if alt text is missing.

## Related issues and documents

Closes #3